### PR TITLE
Set correct POST methods for SSLCommerz callback routes in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Route::controller(SslcommerzController::class)
     ->prefix('sslcommerz') // prefix to avoid conflicts
     ->name('sslc.')
     ->group(function () {
-        Route::get('success', 'success')->name('success');
-        Route::get('failure', 'failure')->name('failure');
-        Route::get('cancel', 'cancel')->name('cancel');
-        Route::get('ipn', 'ipn')->name('ipn');
+        Route::post('success', 'success')->name('success');
+        Route::post('failure', 'failure')->name('failure');
+        Route::post('cancel', 'cancel')->name('cancel');
+        Route::post('ipn', 'ipn')->name('ipn');
     });
 ```
 


### PR DESCRIPTION
The current README specifies GET methods for the callback routes, but SSLCommerz actually sends the callback requests using the POST method. This PR updates the documentation to correct the routes from GET to POST, ensuring that developers integrating with SSLCommerz use the correct HTTP method for callbacks.

This change improves accuracy and prevents potential issues during implementation.