### PR TITLE
Don't encode data while verifying hash

### DIFF
--- a/src/SslcommerzClient.php
+++ b/src/SslcommerzClient.php
@@ -233,7 +233,11 @@ class SslcommerzClient
         }
 
         ksort($dataToHash);
-        $hashString = http_build_query($dataToHash, '', '&');
+        $hashString = "";
+        foreach ($dataToHash as $key => $value) {
+            $hashString .= $key . '=' . ($value) . '&';
+        }
+        $hashString = rtrim($hashString, '&');
 
         return md5($hashString) === $data['verify_sign'];
     }


### PR DESCRIPTION
Some value of SSLCOMMERZ contains space.

While verifying hash `http_build_query` function encodes the spaces as + (plus) character and verification fails.

I've used the method [used by sslcommerz official library](https://github.com/karim-007/sslcommerz-laravel/blob/7e1cbcbd5803e1bada1d502b5ef2c430a87292ea/src/SslCommerz/SslCommerzNotification.php#L203-L207)